### PR TITLE
Remove unnecessary imports

### DIFF
--- a/congan_train.py
+++ b/congan_train.py
@@ -15,7 +15,6 @@ from tensorboardX import SummaryWriter
 import pdb
 import gpustat
 
-import models.dcgan as dcgan
 from models.conwgan import *
 
 import torch

--- a/gan_train.py
+++ b/gan_train.py
@@ -15,7 +15,6 @@ from tensorboardX import SummaryWriter
 import pdb
 import gpustat
 
-import models.dcgan as dcgan
 from models.wgan import *
 
 import torch


### PR DESCRIPTION
Thank you for your implementation first. 

When I was trying to run it, I found that the lines `import models.dcgan as dcgan` in both Python scripts caused error. So I removed them and everything is working fine now.